### PR TITLE
feat(openstacksdk): migrate role to common collection

### DIFF
--- a/extensions/molecule/glance-image/prepare.yml
+++ b/extensions/molecule/glance-image/prepare.yml
@@ -13,14 +13,6 @@
           - python3-pip
         update_cache: true
 
-    - name: Install Python packages used by the test
-      ansible.builtin.pip:
-        name:
-          - "jmespath<1.1.0"
-          - kubernetes
-          - "openstacksdk>1"
-        extra_args: --break-system-packages
-
 - name: Install Kubernetes
   ansible.builtin.import_playbook: vexxhost.atmosphere.kubernetes
 
@@ -31,8 +23,6 @@
   hosts: controllers
   become: true
   gather_facts: true
-  environment:
-    PIP_BREAK_SYSTEM_PACKAGES: "1"
   pre_tasks:
     - name: Expose OS family for Atmosphere roles
       ansible.builtin.set_fact:
@@ -47,7 +37,6 @@
     - role: vexxhost.atmosphere.memcached
     - role: vexxhost.atmosphere.keycloak
     - role: vexxhost.atmosphere.keystone
-    - role: vexxhost.atmosphere.openstacksdk
     - role: vexxhost.atmosphere.glance
 
 - name: Prepare local image source

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ version = "0.6.0"
 dependencies = [
     "ansible-core>=2.18.4,<2.19.0",
     "docker-image-py>=0.1.13",
-    "jmespath>=1.0.1,<1.1.0",
+    "jmespath>=1.0.1",
     "kubernetes>=33.1.0",
     "pydantic>=2",
 ]

--- a/roles/openstacksdk/README.md
+++ b/roles/openstacksdk/README.md
@@ -1,0 +1,4 @@
+# `openstacksdk`
+
+This role installs OpenStack SDK and writes the OpenStack client cloud
+configuration used by Atmosphere automation.

--- a/roles/openstacksdk/defaults/main.yml
+++ b/roles/openstacksdk/defaults/main.yml
@@ -1,0 +1,7 @@
+# Copyright (c) 2024 VEXXHOST, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+# Set this to pin the exact ``openstacksdk`` version installed by pip-based
+# role installs. When unset, pip-based installs use ``openstacksdk>1`` to avoid
+# old SDK versions that are incompatible with supported Python releases.
+# openstacksdk_version:

--- a/roles/openstacksdk/meta/main.yml
+++ b/roles/openstacksdk/meta/main.yml
@@ -1,9 +1,9 @@
-# Copyright (c) 2026 VEXXHOST, Inc.
+# Copyright (c) 2024 VEXXHOST, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 galaxy_info:
   author: VEXXHOST, Inc.
-  description: Ansible role for managing OpenStack Glance images
+  description: Ansible role for OpenStack SDK
   license: Apache-2.0
   min_ansible_version: 5.5.0
   standalone: false
@@ -17,7 +17,3 @@ galaxy_info:
         - focal
         - jammy
         - noble
-
-dependencies:
-  - role: atmosphere.common.qemu_utils
-  - role: atmosphere.common.openstacksdk

--- a/roles/openstacksdk/tasks/main.yml
+++ b/roles/openstacksdk/tasks/main.yml
@@ -1,0 +1,46 @@
+# Copyright (c) 2024 VEXXHOST, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+- name: Install openstacksdk using PIP
+  when: >-
+    (ansible_facts['distribution'] == 'Ubuntu'
+    and ansible_facts['distribution_major_version'] is version('22', '<='))
+    or (ansible_facts['distribution'] == 'Debian'
+    and ansible_facts['distribution_major_version'] is version('12', '<='))
+    or ansible_facts['distribution'] in ['AlmaLinux', 'RedHat', 'Rocky']
+  ansible.builtin.pip:
+    name: >-
+      {{ 'openstacksdk==' + openstacksdk_version
+         if openstacksdk_version is defined
+         else 'openstacksdk>1' }}
+  register: _openstacksdk_pip_install
+  retries: 3
+  delay: 5
+  until: _openstacksdk_pip_install is not failed
+
+- name: Install openstacksdk using package manager
+  when: >-
+    (ansible_facts['distribution'] == 'Ubuntu'
+    and ansible_facts['distribution_major_version'] is version('22', '>'))
+    or (ansible_facts['distribution'] == 'Debian'
+    and ansible_facts['distribution_major_version'] is version('12', '>'))
+  ansible.builtin.package:
+    name: python3-openstacksdk
+
+- name: Create openstack config directory
+  become: true
+  ansible.builtin.file:
+    path: /etc/openstack
+    state: directory
+    owner: root
+    group: root
+    mode: "0600"
+
+- name: Generate cloud config file
+  become: true
+  ansible.builtin.template:
+    src: clouds.yaml.j2
+    dest: /etc/openstack/clouds.yaml
+    owner: root
+    group: root
+    mode: "0600"

--- a/roles/openstacksdk/templates/clouds.yaml.j2
+++ b/roles/openstacksdk/templates/clouds.yaml.j2
@@ -1,0 +1,19 @@
+clouds:
+  atmosphere:
+    auth:
+      auth_url: "https://{{ openstack_helm_endpoints_keystone_api_host }}"
+      username: "admin-{{ openstack_helm_endpoints_region_name }}"
+      password: "{{ openstack_helm_endpoints_keystone_admin_password }}"
+      project_name: admin
+      user_domain_name: Default
+      project_domain_name: Default
+    region_name: "{{ openstack_helm_endpoints_keystone_region_name }}"
+{% if cluster_issuer_type is defined and cluster_issuer_type in ('self-signed', 'ca', 'venafi') %}
+{% if ansible_facts.os_family == 'Debian' %}
+    cacert: "/usr/local/share/ca-certificates/atmosphere.crt"
+{% elif ansible_facts.os_family == 'RedHat' %}
+    cacert: "/etc/pki/ca-trust/source/anchors/atmosphere.crt"
+{% endif %}
+{% elif cluster_issuer_acme_private_ca is defined and cluster_issuer_acme_private_ca | bool %}
+    cacert: "/etc/ssl/certs/ca-certificates.crt"
+{% endif %}

--- a/uv.lock
+++ b/uv.lock
@@ -64,7 +64,7 @@ dev = [
 requires-dist = [
     { name = "ansible-core", specifier = ">=2.18.4,<2.19.0" },
     { name = "docker-image-py", specifier = ">=0.1.13" },
-    { name = "jmespath", specifier = ">=1.0.1,<1.1.0" },
+    { name = "jmespath", specifier = ">=1.0.1" },
     { name = "kubernetes", specifier = ">=33.1.0" },
     { name = "pydantic", specifier = ">=2" },
 ]


### PR DESCRIPTION
## Summary

- migrate the `openstacksdk` role from `vexxhost/atmosphere` into `atmosphere.common`
- make `atmosphere.common.glance_image` depend on the local `openstacksdk` role so SDK setup happens automatically
- install `openstacksdk` via distro packages on newer Debian/Ubuntu systems to avoid PEP 668 system-pip failures
- keep the `glance-image` Molecule scenario out of GitHub Actions because it is covered by Zuul
- keep Glance Molecule controller-only Python dependencies in `pyproject.toml` instead of installing `jmespath`/`kubernetes` as target packages

## Validation

- `nix develop -c env UV_PROJECT_ENVIRONMENT=/tmp/atmosphere-common-venv uv run --with ansible-lint ansible-lint roles/openstacksdk roles/glance_image extensions/molecule/glance-image`
- installed the collection into `/tmp` and ran `ansible-playbook --syntax-check playbooks/glance_image.yaml`
- `git diff --check`