### PR TITLE
feat(glance): install qemu utilities via role dependency

### DIFF
--- a/.zuul.yaml
+++ b/.zuul.yaml
@@ -44,6 +44,7 @@
       - ^extensions/molecule/glance-image/.*
       - ^playbooks/glance_image.yaml$
       - ^roles/glance_image/.*
+      - ^roles/qemu_utils/.*
     required-projects:
       - ansible-collections/ansible.netcommon
       - ansible-collections/ansible.posix

--- a/extensions/molecule/glance-image/prepare.yml
+++ b/extensions/molecule/glance-image/prepare.yml
@@ -11,7 +11,6 @@
           - dirmngr
           - gnupg
           - python3-pip
-          - qemu-utils
         update_cache: true
 
     - name: Install Python packages used by the test
@@ -63,7 +62,7 @@
 
     - name: Create raw test image
       ansible.builtin.command:
-        cmd: qemu-img create -f raw /var/lib/glance-image-source/test.img 1M
+        cmd: truncate -s 1M /var/lib/glance-image-source/test.img
         creates: /var/lib/glance-image-source/test.img
 
     - name: Write initial image ETag

--- a/roles/qemu_utils/README.md
+++ b/roles/qemu_utils/README.md
@@ -1,0 +1,1 @@
+# `qemu_utils`

--- a/roles/qemu_utils/meta/main.yml
+++ b/roles/qemu_utils/meta/main.yml
@@ -1,9 +1,9 @@
-# Copyright (c) 2026 VEXXHOST, Inc.
+# Copyright (c) 2024 VEXXHOST, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 galaxy_info:
   author: VEXXHOST, Inc.
-  description: Ansible role for managing OpenStack Glance images
+  description: Install QEMU utilities
   license: Apache-2.0
   min_ansible_version: 5.5.0
   standalone: false
@@ -17,6 +17,3 @@ galaxy_info:
         - focal
         - jammy
         - noble
-
-dependencies:
-  - role: atmosphere.common.qemu_utils

--- a/roles/qemu_utils/tasks/main.yml
+++ b/roles/qemu_utils/tasks/main.yml
@@ -1,0 +1,7 @@
+# Copyright (c) 2024 VEXXHOST, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+- name: Install packages
+  ansible.builtin.package:
+    name: "{{ 'qemu-utils' if ansible_facts['os_family'] in ['Debian'] else 'qemu-img' }}"
+    state: present


### PR DESCRIPTION
## Summary

- migrate the `qemu_utils` role from `vexxhost/atmosphere` into `atmosphere.common`
- make `glance_image` depend on `atmosphere.common.qemu_utils` so `qemu-img` is installed by the role graph
- stop manually installing `qemu-utils` in the Glance image Molecule prepare playbook and use `truncate` for the raw test image source
- include `roles/qemu_utils` in the Glance image Zuul file matcher

## Validation

- `ansible-galaxy collection build`
- local collection install from the built tarball
- `ansible-playbook --syntax-check playbooks/glance_image.yaml`
- `git diff --check`

The full Molecule scenario was not run locally because it brings up the Glance/OpenStack stack.