### PR TITLE
ci: add manual Galaxy publish retry

### DIFF
--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -4,6 +4,12 @@ on:
   push:
     branches:
       - main
+  workflow_dispatch:
+    inputs:
+      version:
+        description: Release version to publish to Ansible Galaxy, for example 0.7.0
+        required: true
+        type: string
 
 permissions:
   contents: write
@@ -12,7 +18,10 @@ permissions:
 
 jobs:
   release-please:
+    if: ${{ github.event_name == 'push' }}
     runs-on: ubuntu-latest
+    outputs:
+      release_created: ${{ steps.release.outputs.release_created }}
     steps:
       - name: Harden the runner (Audit all outbound calls)
         uses: step-security/harden-runner@a90bcbc6539c36a85cdfeb73f7e2f433735f215b # v2.15.0
@@ -21,9 +30,37 @@ jobs:
 
       - uses: googleapis/release-please-action@c2a5a2bd6a758a0937f1ddb1e8950609867ed15c # v4.3.0
         id: release
+
+  galaxy:
+    needs: release-please
+    if: ${{ always() && (github.event_name == 'workflow_dispatch' || needs.release-please.outputs.release_created == 'true') }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@a90bcbc6539c36a85cdfeb73f7e2f433735f215b # v2.15.0
+        with:
+          egress-policy: audit
+
+      - name: Resolve publish ref
+        id: publish
+        env:
+          VERSION: ${{ inputs.version }}
+        run: |
+          if [ "$GITHUB_EVENT_NAME" = "workflow_dispatch" ]; then
+            if [[ ! "$VERSION" =~ ^[0-9]+(\.[0-9]+){2}([.-][0-9A-Za-z.-]+)?$ ]]; then
+              echo "version must look like 0.7.0" >&2
+              exit 1
+            fi
+
+            echo "ref=v$VERSION" >> "$GITHUB_OUTPUT"
+          else
+            echo "ref=$GITHUB_SHA" >> "$GITHUB_OUTPUT"
+          fi
+
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
-        if: ${{ steps.release.outputs.release_created }}
+        with:
+          ref: ${{ steps.publish.outputs.ref }}
+
       - uses: ansible/ansible-publish-action@a56a0328c92c1d4feedf5bd7f7cf7ec7a4ae3f09 # v1.0.0
-        if: ${{ steps.release.outputs.release_created }}
         with:
           api_key: ${{ secrets.ANSIBLE_GALAXY_TOKEN }}


### PR DESCRIPTION
## Summary
- split Galaxy publishing into its own job so failed publishes can be retried without rerunning release-please
- add a manual `workflow_dispatch` path that accepts a release version and checks out `v<version>` before publishing to Galaxy

## Validation
- `nix-shell -p actionlint --run 'actionlint .github/workflows/release-please.yaml'`
- manually dispatched `release-please` on `codex/galaxy-publish-dispatch` with `version=0.7.0`: https://github.com/vexxhost/atmosphere.common/actions/runs/26227499237
- the retry checked out `v0.7.0`, built `atmosphere-common-0.7.0.tar.gz`, and Galaxy reported the collection was successfully published and imported