### PR TITLE
fix(secretgen): render release template explicitly

### DIFF
--- a/roles/secretgen_controller/tasks/main.yml
+++ b/roles/secretgen_controller/tasks/main.yml
@@ -4,4 +4,5 @@
 - name: Deploy secretgen-controller
   kubernetes.core.k8s:
     state: present
-    template: release.yml.tpl
+    definition: >-
+      {{ lookup('ansible.builtin.template', 'release.yml.tpl') | from_yaml_all | list }}


### PR DESCRIPTION
## Summary

Render the `secretgen_controller` release template before passing it to `kubernetes.core.k8s`.

Depends-On: https://github.com/vexxhost/atmosphere.common/pull/118

## Changes

- replace `template: release.yml.tpl` with an explicit `definition` rendered by `lookup('ansible.builtin.template', 'release.yml.tpl') | from_yaml_all | list`
- keep the role compatible with newer Ansible and `kubernetes.core` behavior where the old template path can pass raw Jinja into Kubernetes manifests

## Validation

- `git diff --check`
- `pre-commit run --files roles/secretgen_controller/tasks/main.yml`
- installed the collection into a temporary `ANSIBLE_COLLECTIONS_PATH`
- `ANSIBLE_COLLECTIONS_PATH=<tmp> uv run ansible-playbook --syntax-check playbooks/secretgen_controller.yaml`
- `ANSIBLE_COLLECTIONS_PATH=<tmp> uv run ansible-playbook --syntax-check extensions/molecule/secretgen-controller/converge.yml`
- rendered `release.yml.tpl` through Ansible and confirmed the Deployment image resolves to `ghcr.io/carvel-dev/secretgen-controller@sha256:59ec05ce5847bfd70c8e04f08b5195e918c8f6fbb947ffc91b456494a2958fd5`

Note: local `uv run ansible-lint roles/secretgen_controller/tasks/main.yml` could not run because the local entry point resolved to an old Python 3.8 global `ansible-lint` and failed importing `functools.cache` before linting. The GitHub `ansible/ansible-lint` job should provide the authoritative lint result.

Related: https://github.com/vexxhost/atmosphere/pull/4009
