### PR TITLE
ci: stabilize molecule and Metal3 jobs

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -108,6 +108,7 @@ jobs:
             --extra-vars target=localhost \
             --extra-vars kubeconfig_path=$HOME/.kube/config \
             --extra-vars ironic_standalone_ip_address=172.18.0.2 \
+            --extra-vars ironic_standalone_deploy_ramdisk_disable_downloader=true \
             --extra-vars ironic_standalone_dhcp_cidr=172.18.0.0/24 \
             --extra-vars ironic_standalone_dhcp_range_start=172.18.0.10 \
             --extra-vars ironic_standalone_dhcp_range_end=172.18.0.20 \
@@ -131,7 +132,12 @@ jobs:
             --namespace baremetal-operator-system \
             --for=condition=available \
             --timeout=5m \
-            deployment.apps/baremetal-operator-controller-manager \
+            deployment.apps/baremetal-operator-controller-manager
+      - run: |
+          kubectl wait \
+            --namespace baremetal-operator-system \
+            --for=condition=available \
+            --timeout=10m \
             deployment.apps/ironic-service
       - run: |
           kubectl wait \
@@ -139,6 +145,14 @@ jobs:
             --for=condition=available \
             --timeout=5m \
             deployment.apps/ironic-standalone-operator-controller-manager
+      - name: Dump Metal3 diagnostics
+        if: failure()
+        run: |
+          kubectl get all --namespace baremetal-operator-system --output=wide || true
+          kubectl get events --namespace baremetal-operator-system --sort-by=.lastTimestamp || true
+          kubectl describe deployment.apps/ironic-service --namespace baremetal-operator-system || true
+          kubectl describe pods --namespace baremetal-operator-system || true
+          kubectl logs deployment.apps/ironic-service --namespace baremetal-operator-system --all-containers --tail=200 || true
 
   dellhw_exporter:
     runs-on: ubuntu-latest

--- a/extensions/molecule/default/prepare.yml
+++ b/extensions/molecule/default/prepare.yml
@@ -3,6 +3,8 @@
 
 - name: Prepare
   hosts: "{{ target | default('all') }}"
+  vars:
+    molecule_kubernetes_python_package: kubernetes==33.1.0
   tasks:
     - name: Install PIP
       ansible.builtin.package:
@@ -11,4 +13,4 @@
 
     - name: Install Kubernetes python package
       ansible.builtin.pip:
-        name: kubernetes
+        name: "{{ molecule_kubernetes_python_package }}"

--- a/roles/ironic_standalone/defaults/main.yaml
+++ b/roles/ironic_standalone/defaults/main.yaml
@@ -7,6 +7,9 @@ ironic_standalone_namespace: baremetal-operator-system
 # Name of the Ironic Standalone instance
 ironic_standalone_name: ironic
 
+# Disable the IPA downloader init container
+ironic_standalone_deploy_ramdisk_disable_downloader: false
+
 # Interface for Ironic Standalone
 ironic_standalone_interface: "{{ ansible_default_ipv4.interface }}"
 

--- a/roles/ironic_standalone/tasks/main.yaml
+++ b/roles/ironic_standalone/tasks/main.yaml
@@ -36,6 +36,8 @@
           name: "{{ ironic_standalone_name }}"
           namespace: "{{ ironic_standalone_namespace }}"
         spec:
+          deployRamdisk:
+            disableDownloader: "{{ ironic_standalone_deploy_ramdisk_disable_downloader | bool }}"
           networking:
             interface: "{{ ironic_standalone_interface }}"
             ipAddress: "{{ ironic_standalone_ip_address }}"
@@ -44,3 +46,7 @@
               rangeBegin: "{{ ironic_standalone_dhcp_range_start }}"
               rangeEnd: "{{ ironic_standalone_dhcp_range_end }}"
               serveDNS: true
+  register: ironic_standalone_apply
+  until: ironic_standalone_apply is not failed
+  retries: 5
+  delay: 5


### PR DESCRIPTION
## Summary

Separate the CI stabilization work that was previously bundled into #117 from the `secretgen_controller` runtime fix.

## Changes

- pin the Molecule Kubernetes Python client to `kubernetes==33.1.0` to avoid replacing Debian-provided PyYAML
- retry the Ironic custom resource apply when the Kubernetes API briefly returns a 503
- allow the Metal3 CI smoke test to disable the IPA downloader it does not exercise
- wait for the Ironic service independently and collect diagnostics when Metal3 CI fails

## Why

These changes address failures in the repository-wide `external-secrets-operator` and `metal3` jobs. They are not part of the `secretgen_controller` template-rendering fix required by vexxhost/atmosphere#4009, so they are moved out of #117 to keep that PR focused.

## Validation

- `git diff --check origin/main..HEAD`
- `pre-commit run --files .github/workflows/ci.yaml extensions/molecule/default/prepare.yml roles/ironic_standalone/defaults/main.yaml roles/ironic_standalone/tasks/main.yaml`
- the same patch previously passed pre-commit, ansible-lint, Metal3, external-secrets-operator, and `oss/check` while it was present on #117
