### PR TITLE
fix(glance_image): reconcile image ownership, visibility, and properties

### DIFF
--- a/.github/workflows/conventional-commit.yaml
+++ b/.github/workflows/conventional-commit.yaml
@@ -24,3 +24,4 @@ jobs:
       - uses: ytanikin/pr-conventional-commits@b72758283dcbee706975950e96bc4bf323a8d8c0 # 1.4.2
         with:
           task_types: '["build", "chore", "ci", "docs", "feat", "fix", "perf", "refactor", "revert", "style", "test"]'
+          add_label: false

--- a/extensions/molecule/glance-image/verify.yml
+++ b/extensions/molecule/glance-image/verify.yml
@@ -41,6 +41,40 @@
           - _idempotent_image.images | length == 1
           - _idempotent_image.images[0].id == _initial_image.images[0].id
 
+    - name: Read the service project
+      openstack.cloud.project_info:
+        cloud: atmosphere
+        name: service
+        domain: service
+      register: _service_project
+
+    - name: Reconcile unchanged image access policy
+      ansible.builtin.include_role:
+        name: atmosphere.common.glance_image
+      vars:
+        glance_image_name: molecule-glance-image
+        glance_image_url: http://127.0.0.1:18080/test.img
+        glance_image_container_format: bare
+        glance_image_disk_format: raw
+        glance_image_owner: service
+        glance_image_owner_domain: service
+        glance_image_is_public: false
+
+    - name: Read image after access policy reconciliation
+      openstack.cloud.image_info:
+        cloud: atmosphere
+        image: molecule-glance-image
+      register: _reconciled_image
+
+    - name: Assert access policy changes without re-upload
+      ansible.builtin.assert:
+        that:
+          - _service_project.projects | length == 1
+          - _reconciled_image.images | length == 1
+          - _reconciled_image.images[0].id == _initial_image.images[0].id
+          - _reconciled_image.images[0].owner_id == _service_project.projects[0].id
+          - _reconciled_image.images[0].visibility == 'private'
+
     - name: Change source ETag
       become: true
       ansible.builtin.copy:

--- a/extensions/molecule/glance-image/verify.yml
+++ b/extensions/molecule/glance-image/verify.yml
@@ -59,6 +59,8 @@
         glance_image_owner: service
         glance_image_owner_domain: service
         glance_image_is_public: false
+        glance_image_properties:
+          molecule_glance_contract: v1
 
     - name: Read image after access policy reconciliation
       openstack.cloud.image_info:
@@ -74,6 +76,9 @@
           - _reconciled_image.images[0].id == _initial_image.images[0].id
           - _reconciled_image.images[0].owner_id == _service_project.projects[0].id
           - _reconciled_image.images[0].visibility == 'private'
+          - >-
+            _reconciled_image.images[0].properties.molecule_glance_contract
+            == 'v1'
 
     - name: Change source ETag
       become: true

--- a/roles/glance_image/README.md
+++ b/roles/glance_image/README.md
@@ -42,7 +42,12 @@ are replaced with `atmosphere:image:obsolete`.
 Images uploaded by earlier versions of Atmosphere lack these properties and are
 treated as outdated on the next run, which causes a one-time re-upload.
 
-## Access Policy
+## Managed Properties And Access Policy
+
+Set `glance_image_properties` to reconcile the requested custom properties even
+when the source URL and ETag are unchanged. The role preserves properties that
+are not present in the requested mapping; removing a key from inventory does
+not delete it from an existing image.
 
 Set `glance_image_owner` and, when needed, `glance_image_owner_domain` to keep
 an image in a service project rather than the project used by the deployment

--- a/roles/glance_image/README.md
+++ b/roles/glance_image/README.md
@@ -41,3 +41,11 @@ are replaced with `atmosphere:image:obsolete`.
 
 Images uploaded by earlier versions of Atmosphere lack these properties and are
 treated as outdated on the next run, which causes a one-time re-upload.
+
+## Access Policy
+
+Set `glance_image_owner` and, when needed, `glance_image_owner_domain` to keep
+an image in a service project rather than the project used by the deployment
+credential. Set `glance_image_is_public` explicitly to manage visibility. The
+role reconciles these values even when the source URL and ETag are unchanged,
+so an upgrade repairs existing images without downloading them again.

--- a/roles/glance_image/tasks/main.yml
+++ b/roles/glance_image/tasks/main.yml
@@ -131,6 +131,8 @@
           }}
         kernel: "{{ glance_image_kernel | default(omit) }}"
         ramdisk: "{{ glance_image_ramdisk | default(omit) }}"
+        owner: "{{ glance_image_owner | default(omit) }}"
+        owner_domain: "{{ glance_image_owner_domain | default(omit) }}"
         is_public: "{{ glance_image_is_public | default(omit) }}"
         tags: "{{ glance_image_tags | default(omit) }}"
         wait: true
@@ -176,3 +178,65 @@
         path: "{{ _glance_image_workdir.path }}"
         state: absent
       when: _glance_image_workdir.path is defined
+
+- name: Select the current managed image
+  run_once: true
+  ansible.builtin.set_fact:
+    _glance_image_managed_id: >-
+      {{
+        _glance_image_upload_result.image.id
+        if _glance_image_needs_upload
+        else _glance_image_existing.id
+      }}
+
+- name: Resolve the requested image owner project
+  run_once: true
+  when: glance_image_owner is defined
+  openstack.cloud.project_info:
+    cloud: "{{ glance_image_cloud }}"
+    name: "{{ glance_image_owner }}"
+    domain: "{{ glance_image_owner_domain | default(omit) }}"
+  register: _glance_image_owner_project
+
+- name: Validate the requested image owner project
+  run_once: true
+  when: glance_image_owner is defined
+  ansible.builtin.assert:
+    that:
+      - _glance_image_owner_project.projects | length == 1
+    fail_msg: >-
+      Expected exactly one project matching {{ glance_image_owner }} for
+      Glance image ownership reconciliation.
+
+- name: Reconcile image ownership and visibility
+  run_once: true
+  when: >-
+    glance_image_owner is defined
+    or glance_image_is_public is defined
+  vars:
+    _glance_image_access_attributes: >-
+      {{
+        {'id': _glance_image_managed_id}
+        | combine(
+            {'owner': _glance_image_owner_project.projects[0].id}
+            if glance_image_owner is defined else {}
+          )
+        | combine(
+            {'visibility': ('public' if glance_image_is_public | bool else 'private')}
+            if glance_image_is_public is defined else {}
+          )
+      }}
+  openstack.cloud.resource:
+    cloud: "{{ glance_image_cloud }}"
+    service: image
+    type: image
+    attributes: "{{ _glance_image_access_attributes }}"
+    updateable_attributes: >-
+      {{
+        (['owner'] if glance_image_owner is defined else [])
+        + (['visibility'] if glance_image_is_public is defined else [])
+      }}
+  retries: "{{ glance_image_retries }}"
+  delay: 5
+  register: _glance_image_access_result
+  until: _glance_image_access_result is not failed

--- a/roles/glance_image/tasks/main.yml
+++ b/roles/glance_image/tasks/main.yml
@@ -208,7 +208,7 @@
       Expected exactly one project matching {{ glance_image_owner }} for
       Glance image ownership reconciliation.
 
-- name: Reconcile image ownership and visibility
+- name: Reconcile image access policy
   run_once: true
   when: >-
     glance_image_owner is defined
@@ -238,5 +238,31 @@
       }}
   retries: "{{ glance_image_retries }}"
   delay: 5
-  register: _glance_image_access_result
-  until: _glance_image_access_result is not failed
+  register: _glance_image_reconcile_result
+  until: _glance_image_reconcile_result is not failed
+
+- name: Reconcile image properties
+  run_once: true
+  when:
+    - glance_image_properties | default({}) | length > 0
+    - >-
+      (
+        glance_image_properties
+        | dict2items
+        | difference(_glance_image_existing_props | dict2items)
+        | length
+      ) > 0
+  openstack.cloud.image:
+    cloud: "{{ glance_image_cloud }}"
+    id: "{{ _glance_image_managed_id }}"
+    name: "{{ glance_image_name }}"
+    is_public: >-
+      {{
+        glance_image_is_public
+        | default(_glance_image_existing.visibility == 'public')
+      }}
+    properties: "{{ glance_image_properties }}"
+  retries: "{{ glance_image_retries }}"
+  delay: 5
+  register: _glance_image_properties_result
+  until: _glance_image_properties_result is not failed


### PR DESCRIPTION
This PR combines image ownership, visibility, and custom property reconciliation into the `glance_image` role:

- **Commit 1**: Reconcile Glance image ownership and visibility in place when source URL and ETag are unchanged. Resolves owner names to project IDs and uses the generic OpenStack SDK resource module.
- **Commit 2**: Reconcile requested custom properties (`glance_image_properties`) on existing managed images while preserving unmanaged properties.