### PR TITLE
feat(glance_image): import verified Glance images from OCI artifacts

### DIFF
--- a/.github/workflows/conventional-commit.yaml
+++ b/.github/workflows/conventional-commit.yaml
@@ -24,3 +24,4 @@ jobs:
       - uses: ytanikin/pr-conventional-commits@b72758283dcbee706975950e96bc4bf323a8d8c0 # 1.4.2
         with:
           task_types: '["build", "chore", "ci", "docs", "feat", "fix", "perf", "refactor", "revert", "style", "test"]'
+          add_label: false

--- a/roles/glance_image/README.md
+++ b/roles/glance_image/README.md
@@ -21,9 +21,10 @@ glance_image_oci_sha512: <qcow2-sha512>
 # glance_image_oci_authfile: /run/secrets/registry-auth.json
 ```
 
-The role installs `skopeo`, selects the declared Linux architecture, extracts
-only the requested regular file, and verifies SHA512 before upload. An OCI
-reference without a manifest digest is rejected.
+The role installs `skopeo`, selects the declared Linux architecture, streams
+the requested regular file from compressed or uncompressed layers, and
+verifies SHA512 before upload. An OCI reference without a manifest digest is
+rejected.
 
 ## Change Detection
 

--- a/roles/glance_image/README.md
+++ b/roles/glance_image/README.md
@@ -1,13 +1,36 @@
 # `glance_image`
 
 This role uploads an image into OpenStack Glance and keeps it in sync with the
-upstream source URL.
+declared source.
+
+## Sources
+
+HTTP remains the default:
+
+```yaml
+glance_image_url: https://images.example/image.qcow2
+```
+
+An image can instead be extracted from a public or authenticated OCI image.
+The manifest and payload must both be immutable:
+
+```yaml
+glance_image_oci_reference: registry.example/image@sha256:<manifest-digest>
+glance_image_oci_path: /images/image.qcow2
+glance_image_oci_sha512: <qcow2-sha512>
+# glance_image_oci_authfile: /run/secrets/registry-auth.json
+```
+
+The role installs `skopeo`, selects the declared Linux architecture, extracts
+only the requested regular file, and verifies SHA512 before upload. An OCI
+reference without a manifest digest is rejected.
 
 ## Change Detection
 
-On every run, the role sends an HTTP `HEAD` request to `glance_image_url` to
-check for changes. The download and upload steps are skipped when no change is
-detected.
+For an HTTP source, the role sends a `HEAD` request to `glance_image_url` to
+check for changes. For OCI, the digest-pinned reference, artifact path, and
+required SHA512 form the source identity. Download and upload are skipped when
+that identity is already recorded on the Glance image.
 
 If the server returns an `ETag` header, the role captures it and compares it
 against the `atmosphere:image:etag` property stored on any existing image with

--- a/roles/glance_image/defaults/main.yml
+++ b/roles/glance_image/defaults/main.yml
@@ -4,12 +4,12 @@
 glance_image_cloud: atmosphere
 
 # glance_image_tempfile_path:
-# glance_image_url:
-# glance_image_oci_reference:
-# glance_image_oci_path:
-# glance_image_oci_sha512:
+glance_image_url: ""
+glance_image_oci_reference: ""
+glance_image_oci_path: ""
+glance_image_oci_sha512: ""
 glance_image_oci_architecture: amd64
-# glance_image_oci_authfile:
+glance_image_oci_authfile: ""
 
 glance_image_http_proxy: "{{ http_proxy | default('') }}"
 glance_image_https_proxy: "{{ https_proxy | default('') }}"

--- a/roles/glance_image/defaults/main.yml
+++ b/roles/glance_image/defaults/main.yml
@@ -4,6 +4,12 @@
 glance_image_cloud: atmosphere
 
 # glance_image_tempfile_path:
+# glance_image_url:
+# glance_image_oci_reference:
+# glance_image_oci_path:
+# glance_image_oci_sha512:
+glance_image_oci_architecture: amd64
+# glance_image_oci_authfile:
 
 glance_image_http_proxy: "{{ http_proxy | default('') }}"
 glance_image_https_proxy: "{{ https_proxy | default('') }}"

--- a/roles/glance_image/files/extract_oci_file.py
+++ b/roles/glance_image/files/extract_oci_file.py
@@ -5,7 +5,6 @@
 
 from __future__ import annotations
 
-import io
 import json
 from pathlib import Path, PurePosixPath
 import shutil
@@ -39,12 +38,12 @@ def _normalized_target(raw_target: str) -> PurePosixPath:
     return normalized
 
 
-def _layer_hides_target(names: set[str], target: PurePosixPath) -> bool:
+def _layer_hides_target(name: str, target: PurePosixPath) -> bool:
     whiteout = target.parent / f".wh.{target.name}"
-    if str(whiteout) in names:
+    if str(whiteout) == name:
         return True
     for parent in (target.parent, *target.parents):
-        if str(parent / ".wh..wh..opq") in names:
+        if str(parent / ".wh..wh..opq") == name:
             return True
     return False
 
@@ -61,19 +60,23 @@ def extract(archive_path: Path, raw_target: str, output: Path) -> None:
         )
         layers = manifest.get("layers", [])
         for descriptor in reversed(layers):
-            layer_data = _member(archive, _blob_name(descriptor["digest"]))
-            with tarfile.open(fileobj=io.BytesIO(layer_data), mode="r:*") as layer:
-                members = {
-                    (
+            layer_member = archive.getmember(_blob_name(descriptor["digest"]))
+            layer_stream = archive.extractfile(layer_member)
+            if layer_stream is None:
+                raise ValueError("OCI layer has no content")
+            found = False
+            hidden = False
+            with layer_stream, tarfile.open(fileobj=layer_stream, mode="r|*") as layer:
+                for member in layer:
+                    name = (
                         member.name[2:]
                         if member.name.startswith("./")
                         else member.name
-                    ): member
-                    for member in layer.getmembers()
-                }
-                target_name = str(target)
-                if target_name in members:
-                    member = members[target_name]
+                    )
+                    if _layer_hides_target(name, target):
+                        hidden = True
+                    if name != str(target):
+                        continue
                     if not member.isfile():
                         raise ValueError(f"OCI artifact {raw_target} is not a file")
                     stream = layer.extractfile(member)
@@ -81,9 +84,11 @@ def extract(archive_path: Path, raw_target: str, output: Path) -> None:
                         raise ValueError(f"OCI artifact {raw_target} has no content")
                     with output.open("wb") as destination:
                         shutil.copyfileobj(stream, destination)
-                    return
-                if _layer_hides_target(set(members), target):
-                    break
+                    found = True
+            if found:
+                return
+            if hidden:
+                break
     raise FileNotFoundError(f"OCI artifact does not contain {raw_target}")
 
 

--- a/roles/glance_image/files/extract_oci_file.py
+++ b/roles/glance_image/files/extract_oci_file.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026 VEXXHOST, Inc.
+# SPDX-License-Identifier: Apache-2.0
+"""Extract one absolute path from a digest-selected OCI image archive."""
+
+from __future__ import annotations
+
+import io
+import json
+from pathlib import Path, PurePosixPath
+import shutil
+import sys
+import tarfile
+
+
+def _member(archive: tarfile.TarFile, name: str) -> bytes:
+    member = archive.getmember(name)
+    stream = archive.extractfile(member)
+    if stream is None:
+        raise ValueError(f"OCI member {name} has no content")
+    return stream.read()
+
+
+def _blob_name(digest: str) -> str:
+    algorithm, separator, value = digest.partition(":")
+    if separator != ":" or algorithm != "sha256" or len(value) != 64:
+        raise ValueError(f"unsupported OCI digest {digest}")
+    int(value, 16)
+    return f"blobs/{algorithm}/{value}"
+
+
+def _normalized_target(raw_target: str) -> PurePosixPath:
+    target = PurePosixPath(raw_target)
+    if not target.is_absolute() or ".." in target.parts:
+        raise ValueError("OCI artifact path must be absolute and normalized")
+    normalized = PurePosixPath(*target.parts[1:])
+    if not normalized.parts:
+        raise ValueError("OCI artifact path cannot be the root directory")
+    return normalized
+
+
+def _layer_hides_target(names: set[str], target: PurePosixPath) -> bool:
+    whiteout = target.parent / f".wh.{target.name}"
+    if str(whiteout) in names:
+        return True
+    for parent in (target.parent, *target.parents):
+        if str(parent / ".wh..wh..opq") in names:
+            return True
+    return False
+
+
+def extract(archive_path: Path, raw_target: str, output: Path) -> None:
+    target = _normalized_target(raw_target)
+    with tarfile.open(archive_path, "r:*") as archive:
+        index = json.loads(_member(archive, "index.json"))
+        manifests = index.get("manifests", [])
+        if len(manifests) != 1:
+            raise ValueError("OCI archive must contain exactly one selected manifest")
+        manifest = json.loads(
+            _member(archive, _blob_name(manifests[0]["digest"]))
+        )
+        layers = manifest.get("layers", [])
+        for descriptor in reversed(layers):
+            layer_data = _member(archive, _blob_name(descriptor["digest"]))
+            with tarfile.open(fileobj=io.BytesIO(layer_data), mode="r:*") as layer:
+                members = {
+                    (
+                        member.name[2:]
+                        if member.name.startswith("./")
+                        else member.name
+                    ): member
+                    for member in layer.getmembers()
+                }
+                target_name = str(target)
+                if target_name in members:
+                    member = members[target_name]
+                    if not member.isfile():
+                        raise ValueError(f"OCI artifact {raw_target} is not a file")
+                    stream = layer.extractfile(member)
+                    if stream is None:
+                        raise ValueError(f"OCI artifact {raw_target} has no content")
+                    with output.open("wb") as destination:
+                        shutil.copyfileobj(stream, destination)
+                    return
+                if _layer_hides_target(set(members), target):
+                    break
+    raise FileNotFoundError(f"OCI artifact does not contain {raw_target}")
+
+
+if __name__ == "__main__":
+    if len(sys.argv) != 4:
+        raise SystemExit("usage: extract_oci_file.py ARCHIVE PATH OUTPUT")
+    extract(Path(sys.argv[1]), sys.argv[2], Path(sys.argv[3]))

--- a/roles/glance_image/tasks/main.yml
+++ b/roles/glance_image/tasks/main.yml
@@ -6,17 +6,18 @@
   ansible.builtin.assert:
     that:
       - >-
-        (glance_image_url is defined)
-        != (glance_image_oci_reference is defined)
+        (glance_image_url | length > 0)
+        != (glance_image_oci_reference | length > 0)
       - >-
-        glance_image_oci_reference is not defined
-        or glance_image_oci_reference is match('^[^@]+@sha256:[0-9a-f]{64}$')
+        glance_image_oci_reference | length == 0
+        or glance_image_oci_reference
+        is match('^[^@]+@sha256:[0-9a-f]{64}$')
       - >-
-        glance_image_oci_reference is not defined
-        or glance_image_oci_path | default('') is match('^/[^/].*')
+        glance_image_oci_reference | length == 0
+        or glance_image_oci_path is match('^/[^/].*')
       - >-
-        glance_image_oci_reference is not defined
-        or glance_image_oci_sha512 | default('') is match('^[0-9a-f]{128}$')
+        glance_image_oci_reference | length == 0
+        or glance_image_oci_sha512 is match('^[0-9a-f]{128}$')
     fail_msg: >-
       Define exactly one image source: glance_image_url, or a digest-pinned
       glance_image_oci_reference with an absolute artifact path and SHA512.
@@ -27,20 +28,20 @@
     _glance_image_source_url: >-
       {{
         glance_image_url
-        if glance_image_url is defined
+        if glance_image_url | length > 0
         else 'oci://' ~ glance_image_oci_reference ~ '#' ~ glance_image_oci_path
       }}
     # Reset per include_role loop item so a previous source ETag cannot leak.
     _glance_image_source_etag: ""
 
 - name: Capture OCI source checksum
-  when: glance_image_oci_reference is defined
+  when: glance_image_oci_reference | length > 0
   run_once: true
   ansible.builtin.set_fact:
     _glance_image_source_etag: "{{ glance_image_oci_sha512 }}"
 
 - name: Fetch source image metadata from URL
-  when: glance_image_url is defined
+  when: glance_image_url | length > 0
   run_once: true
   ansible.builtin.uri:
     url: "{{ glance_image_url }}"
@@ -59,7 +60,7 @@
 - name: Capture source ETag when available
   run_once: true
   when:
-    - glance_image_url is defined
+    - glance_image_url | length > 0
     - _glance_image_source_head.etag is defined
   ansible.builtin.set_fact:
     _glance_image_source_etag: "{{ _glance_image_source_head.etag | regex_replace('\"', '') }}"
@@ -100,7 +101,7 @@
       register: _glance_image_workdir
 
     - name: Download image from HTTP
-      when: glance_image_url is defined
+      when: glance_image_url | length > 0
       ansible.builtin.get_url:
         url: "{{ glance_image_url }}"
         dest: "{{ _glance_image_workdir.path }}/{{ glance_image_url | basename }}"
@@ -116,12 +117,12 @@
         no_proxy: "{{ glance_image_no_proxy }}"
 
     - name: Capture HTTP image path
-      when: glance_image_url is defined
+      when: glance_image_url | length > 0
       ansible.builtin.set_fact:
         _glance_image_download_dest: "{{ _glance_image_get_url.dest }}"
 
     - name: Extract image from OCI artifact
-      when: glance_image_oci_reference is defined
+      when: glance_image_oci_reference | length > 0
       ansible.builtin.include_tasks: source_oci.yml
 
     - name: Get image format

--- a/roles/glance_image/tasks/main.yml
+++ b/roles/glance_image/tasks/main.yml
@@ -1,7 +1,46 @@
 # Copyright (c) 2026 VEXXHOST, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
+- name: Validate image source contract
+  run_once: true
+  ansible.builtin.assert:
+    that:
+      - >-
+        (glance_image_url is defined)
+        != (glance_image_oci_reference is defined)
+      - >-
+        glance_image_oci_reference is not defined
+        or glance_image_oci_reference is match('^[^@]+@sha256:[0-9a-f]{64}$')
+      - >-
+        glance_image_oci_reference is not defined
+        or glance_image_oci_path | default('') is match('^/[^/].*')
+      - >-
+        glance_image_oci_reference is not defined
+        or glance_image_oci_sha512 | default('') is match('^[0-9a-f]{128}$')
+    fail_msg: >-
+      Define exactly one image source: glance_image_url, or a digest-pinned
+      glance_image_oci_reference with an absolute artifact path and SHA512.
+
+- name: Capture immutable source identity
+  run_once: true
+  ansible.builtin.set_fact:
+    _glance_image_source_url: >-
+      {{
+        glance_image_url
+        if glance_image_url is defined
+        else 'oci://' ~ glance_image_oci_reference ~ '#' ~ glance_image_oci_path
+      }}
+    # Reset per include_role loop item so a previous source ETag cannot leak.
+    _glance_image_source_etag: ""
+
+- name: Capture OCI source checksum
+  when: glance_image_oci_reference is defined
+  run_once: true
+  ansible.builtin.set_fact:
+    _glance_image_source_etag: "{{ glance_image_oci_sha512 }}"
+
 - name: Fetch source image metadata from URL
+  when: glance_image_url is defined
   run_once: true
   ansible.builtin.uri:
     url: "{{ glance_image_url }}"
@@ -19,7 +58,9 @@
 
 - name: Capture source ETag when available
   run_once: true
-  when: _glance_image_source_head.etag is defined
+  when:
+    - glance_image_url is defined
+    - _glance_image_source_head.etag is defined
   ansible.builtin.set_fact:
     _glance_image_source_etag: "{{ _glance_image_source_head.etag | regex_replace('\"', '') }}"
 
@@ -44,8 +85,8 @@
   ansible.builtin.set_fact:
     _glance_image_needs_upload: "{{
       (_glance_image_info.images | length == 0)
-      or ((_glance_image_existing_props['atmosphere:image:url'] | default('')) != glance_image_url)
-      or (_glance_image_source_etag is defined
+      or ((_glance_image_existing_props['atmosphere:image:url'] | default('')) != _glance_image_source_url)
+      or (_glance_image_source_etag | length > 0
           and (_glance_image_existing_props['atmosphere:image:etag'] | default('')) != _glance_image_source_etag) }}"
 
 - name: Download image and upload into Glance
@@ -58,7 +99,8 @@
         state: directory
       register: _glance_image_workdir
 
-    - name: Download image
+    - name: Download image from HTTP
+      when: glance_image_url is defined
       ansible.builtin.get_url:
         url: "{{ glance_image_url }}"
         dest: "{{ _glance_image_workdir.path }}/{{ glance_image_url | basename }}"
@@ -73,22 +115,40 @@
         https_proxy: "{{ glance_image_https_proxy }}"
         no_proxy: "{{ glance_image_no_proxy }}"
 
+    - name: Capture HTTP image path
+      when: glance_image_url is defined
+      ansible.builtin.set_fact:
+        _glance_image_download_dest: "{{ _glance_image_get_url.dest }}"
+
+    - name: Extract image from OCI artifact
+      when: glance_image_oci_reference is defined
+      ansible.builtin.include_tasks: source_oci.yml
+
     - name: Get image format
       changed_when: false
-      ansible.builtin.shell: |
-        set -o pipefail
-        qemu-img info {{ _glance_image_get_url.dest }} | grep -i "file format" | awk '{ print $3 }'
-      args:
-        executable: /bin/bash
+      ansible.builtin.command:
+        argv:
+          - qemu-img
+          - info
+          - --output=json
+          - "{{ _glance_image_download_dest }}"
       register: _glance_image_format
 
     - name: Convert file to target disk format
       when:
         - glance_image_disk_format not in ['aki', 'ari']
-        - glance_image_disk_format != _glance_image_format.stdout
+        - >-
+          glance_image_disk_format
+          != ((_glance_image_format.stdout | from_json).format)
       changed_when: true
       ansible.builtin.command:
-        qemu-img convert -O {{ glance_image_disk_format }} {{ _glance_image_get_url.dest }} {{ _glance_image_get_url.dest }}.converted
+        argv:
+          - qemu-img
+          - convert
+          - -O
+          - "{{ glance_image_disk_format }}"
+          - "{{ _glance_image_download_dest }}"
+          - "{{ _glance_image_download_dest }}.converted"
       register: glance_image_conversion
 
     - name: Wait until image service ready
@@ -118,7 +178,7 @@
       openstack.cloud.image:
         cloud: "{{ glance_image_cloud }}"
         name: "{{ _glance_image_pending_name }}"
-        filename: "{{ _glance_image_get_url.dest }}{% if glance_image_conversion is not skipped %}.converted{% endif %}"
+        filename: "{{ _glance_image_download_dest }}{% if glance_image_conversion is not skipped %}.converted{% endif %}"
         min_disk: "{{ glance_image_min_disk | default(omit) }}"
         min_ram: "{{ glance_image_min_ram | default(omit) }}"
         container_format: "{{ glance_image_container_format | default(omit) }}"
@@ -126,8 +186,8 @@
         properties: >-
           {{
             (glance_image_properties | default({}))
-            | combine({'atmosphere:image:url': glance_image_url})
-            | combine({'atmosphere:image:etag': _glance_image_source_etag} if _glance_image_source_etag is defined else {})
+            | combine({'atmosphere:image:url': _glance_image_source_url})
+            | combine({'atmosphere:image:etag': _glance_image_source_etag} if _glance_image_source_etag | length > 0 else {})
           }}
         kernel: "{{ glance_image_kernel | default(omit) }}"
         ramdisk: "{{ glance_image_ramdisk | default(omit) }}"

--- a/roles/glance_image/tasks/source_oci.yml
+++ b/roles/glance_image/tasks/source_oci.yml
@@ -20,7 +20,7 @@
         ]
         + (
           ['--authfile', glance_image_oci_authfile]
-          if glance_image_oci_authfile is defined
+          if glance_image_oci_authfile | length > 0
           else []
         )
         + [
@@ -30,7 +30,7 @@
       }}
 
 - name: Copy digest-pinned OCI artifact
-  no_log: "{{ glance_image_oci_authfile is defined }}"
+  no_log: "{{ glance_image_oci_authfile | length > 0 }}"
   ansible.builtin.command:
     argv: "{{ _glance_image_skopeo_argv }}"
   changed_when: true

--- a/roles/glance_image/tasks/source_oci.yml
+++ b/roles/glance_image/tasks/source_oci.yml
@@ -15,8 +15,7 @@
           'skopeo',
           'copy',
           '--override-os', 'linux',
-          '--override-arch', glance_image_oci_architecture,
-          '--dest-decompress'
+          '--override-arch', glance_image_oci_architecture
         ]
         + (
           ['--authfile', glance_image_oci_authfile]

--- a/roles/glance_image/tasks/source_oci.yml
+++ b/roles/glance_image/tasks/source_oci.yml
@@ -1,0 +1,71 @@
+# Copyright (c) 2026 VEXXHOST, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+- name: Install OCI transport
+  become: true
+  ansible.builtin.package:
+    name: skopeo
+    state: present
+
+- name: Build OCI copy command
+  ansible.builtin.set_fact:
+    _glance_image_skopeo_argv: >-
+      {{
+        [
+          'skopeo',
+          'copy',
+          '--override-os', 'linux',
+          '--override-arch', glance_image_oci_architecture,
+          '--dest-decompress'
+        ]
+        + (
+          ['--authfile', glance_image_oci_authfile]
+          if glance_image_oci_authfile is defined
+          else []
+        )
+        + [
+          'docker://' ~ glance_image_oci_reference,
+          'oci-archive:' ~ _glance_image_workdir.path ~ '/source.oci'
+        ]
+      }}
+
+- name: Copy digest-pinned OCI artifact
+  no_log: "{{ glance_image_oci_authfile is defined }}"
+  ansible.builtin.command:
+    argv: "{{ _glance_image_skopeo_argv }}"
+  changed_when: true
+
+- name: Install OCI artifact extractor
+  ansible.builtin.copy:
+    src: extract_oci_file.py
+    dest: "{{ _glance_image_workdir.path }}/extract_oci_file.py"
+    mode: "0600"
+
+- name: Extract requested image from OCI artifact
+  ansible.builtin.command:
+    argv:
+      - python3
+      - "{{ _glance_image_workdir.path }}/extract_oci_file.py"
+      - "{{ _glance_image_workdir.path }}/source.oci"
+      - "{{ glance_image_oci_path }}"
+      - "{{ _glance_image_workdir.path }}/source-image"
+  changed_when: true
+
+- name: Verify extracted image SHA512
+  ansible.builtin.stat:
+    path: "{{ _glance_image_workdir.path }}/source-image"
+    checksum_algorithm: sha512
+    get_checksum: true
+  register: _glance_image_oci_stat
+
+- name: Require the reviewed OCI artifact payload
+  ansible.builtin.assert:
+    that:
+      - _glance_image_oci_stat.stat.checksum == glance_image_oci_sha512
+    fail_msg: >-
+      The image extracted from the digest-pinned OCI artifact does not match
+      glance_image_oci_sha512.
+
+- name: Capture OCI image path
+  ansible.builtin.set_fact:
+    _glance_image_download_dest: "{{ _glance_image_workdir.path }}/source-image"


### PR DESCRIPTION
This PR adds support for extracting and importing Glance images directly from digest-pinned OCI container images:

- Extracts a single regular file from a digest-pinned OCI archive using `skopeo` and a dedicated Python layer extraction script.
- Verifies SHA512 checksum of the extracted payload before uploading to Glance.
- Handles compressed OCI archive layers and isolates Glance source variables per invocation loop item.